### PR TITLE
add cuda 11 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -56,6 +56,54 @@ jobs:
         CONFIG: linux_64_cuda_compiler_version10.1float_preclowpython3.9._
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:10.1
+      linux_64_cuda_compiler_version11.0float_prechighpython3.7._:
+        CONFIG: linux_64_cuda_compiler_version11.0float_prechighpython3.7._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.0float_prechighpython3.8._:
+        CONFIG: linux_64_cuda_compiler_version11.0float_prechighpython3.8._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.0float_prechighpython3.9._:
+        CONFIG: linux_64_cuda_compiler_version11.0float_prechighpython3.9._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.0float_preclowpython3.7._:
+        CONFIG: linux_64_cuda_compiler_version11.0float_preclowpython3.7._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.0float_preclowpython3.8._:
+        CONFIG: linux_64_cuda_compiler_version11.0float_preclowpython3.8._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.0float_preclowpython3.9._:
+        CONFIG: linux_64_cuda_compiler_version11.0float_preclowpython3.9._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.1float_prechighpython3.7._:
+        CONFIG: linux_64_cuda_compiler_version11.1float_prechighpython3.7._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
+      linux_64_cuda_compiler_version11.1float_prechighpython3.8._:
+        CONFIG: linux_64_cuda_compiler_version11.1float_prechighpython3.8._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
+      linux_64_cuda_compiler_version11.1float_prechighpython3.9._:
+        CONFIG: linux_64_cuda_compiler_version11.1float_prechighpython3.9._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
+      linux_64_cuda_compiler_version11.1float_preclowpython3.7._:
+        CONFIG: linux_64_cuda_compiler_version11.1float_preclowpython3.7._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
+      linux_64_cuda_compiler_version11.1float_preclowpython3.8._:
+        CONFIG: linux_64_cuda_compiler_version11.1float_preclowpython3.8._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
+      linux_64_cuda_compiler_version11.1float_preclowpython3.9._:
+        CONFIG: linux_64_cuda_compiler_version11.1float_preclowpython3.9._
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
       linux_64_cuda_compiler_version9.2float_prechighpython3.7._:
         CONFIG: linux_64_cuda_compiler_version9.2float_prechighpython3.7._
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.0float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:10.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:
 - high
 numpy:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:
 - high
 numpy:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.8.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:
 - high
 numpy:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.9.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,15 +11,15 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:
-- high
+- low
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,15 +11,15 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:
-- high
+- low
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.8.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,15 +11,15 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.0
 float_prec:
-- high
+- low
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.9.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:
 - high
 numpy:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:
 - high
 numpy:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.8.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:
 - high
 numpy:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.9.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,15 +11,15 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:
-- high
+- low
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,15 +11,15 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:
-- high
+- low
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.8.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '5.4'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
@@ -11,15 +11,15 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '5.4'
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:
-- high
+- low
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -27,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.*
+- 3.9.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos7
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:9.2
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version9.2float_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - high
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_prechighpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.7._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.8._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '5.4'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '5.4'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.3'
+- '5.4'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.3'
+- '5.4'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 float_prec:

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
@@ -21,7 +21,7 @@ docker_image:
 float_prec:
 - low
 numpy:
-- '1.16'
+- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNonefloat_preclowpython3.9._.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 cuda_compiler:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,90 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0float_prechighpython3.7.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0float_prechighpython3.7._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0float_prechighpython3.8.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0float_prechighpython3.8._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0float_prechighpython3.9.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0float_prechighpython3.9._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0float_preclowpython3.7.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0float_preclowpython3.7._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0float_preclowpython3.8.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0float_preclowpython3.8._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0float_preclowpython3.9.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0float_preclowpython3.9._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1float_prechighpython3.7.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1float_prechighpython3.7._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1float_prechighpython3.8.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1float_prechighpython3.8._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1float_prechighpython3.9.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1float_prechighpython3.9._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1float_preclowpython3.7.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1float_preclowpython3.7._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1float_preclowpython3.8.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1float_preclowpython3.8._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1float_preclowpython3.9.</td>
+              <td>
+                <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">
+                  <img src="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_apis/build/status/deepmd-kit-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1float_preclowpython3.9._" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_cuda_compiler_version9.2float_prechighpython3.7.</td>
               <td>
                 <a href="https://dev.azure.com/deepmd-kit-recipes/feedstock-builds/_build/latest?definitionId=1&branchName=master">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,4 +7,4 @@ channels:
   targets:
     -
       - deepmodeling
-channel_priority: disabled
+channel_priority: flexible

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,4 @@ channels:
   targets:
     -
       - deepmodeling
+channel_priority: flexible

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,4 +7,4 @@ channels:
   targets:
     -
       - deepmodeling
-channel_priority: flexible
+channel_priority: disabled

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -43,7 +43,7 @@ c_compiler_version:
 cxx_compiler_version:
 - 5.4
 channel_sources:
-- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
+- deepmodeling,https://deepmodeling.njzjz.win,nvidia,defaults
 channel_targets:
 - deepmodeling dev
 python:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -39,9 +39,9 @@ zip_keys:
     - python_impl
     - numpy
 c_compiler_version:
-- 7.3
+- 5.4
 cxx_compiler_version:
-- 7.3
+- 5.4
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -39,9 +39,9 @@ zip_keys:
     - python_impl
     - numpy
 c_compiler_version:
-- 5.4
+- 7.3
 cxx_compiler_version:
-- 5.4
+- 7.3
 channel_sources:
 - deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,21 +7,29 @@ cuda_compiler_version:
 - 9.2
 - 10.0
 - 10.1
+- 11.0
+- 11.1
 cudnn:
 - undefined
 - 7
 - 7
 - 7
+- 8
+- 8
 cdt_name:
 - cos6
 - cos6
 - cos6
 - cos6
+- cos7
+- cos7
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 - quay.io/condaforge/linux-anvil-cuda:9.2 
 - quay.io/condaforge/linux-anvil-cuda:10.0 
 - quay.io/condaforge/linux-anvil-cuda:10.1 
+- quay.io/condaforge/linux-anvil-cuda:11.0 
+- quay.io/condaforge/linux-anvil-cuda:11.1 
 zip_keys:
   - - cudnn
     - cuda_compiler_version
@@ -35,7 +43,7 @@ c_compiler_version:
 cxx_compiler_version:
 - 5.4
 channel_sources:
-- deepmodeling,defaults
+- deepmodeling,defaults,nvidia,https://deepmodeling.njzjz.win
 channel_targets:
 - deepmodeling dev
 python:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -55,6 +55,6 @@ python_impl:
 - cpython
 - cpython
 numpy:
-- 1.16
-- 1.16
-- 1.16
+- 1.20
+- 1.20
+- 1.20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,12 @@
 {% else %}
 {% set dp_variant = "gpu" %}
 
-{% if cuda_compiler_version == "10.1" %}
-{% set tf_version = "2.4.1" %}
+{% if cuda_compiler_version == "9.2" %}
+{% set tf_version = "1.14" %}
 {% elif cuda_compiler_version == "10.0" %}
 {% set tf_version = "2.0" %}
 {% else %}
-{% set tf_version = "1.14" %}
+{% set tf_version = "2.4.1" %}
 {% endif %}
 
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ requirements:
     - setuptools_scm
     - tensorflow {{ tf_version }}*  # [cuda_compiler_version == 'None']
     - tensorflow-gpu {{ tf_version }}*  # [cuda_compiler_version != 'None']
+    - tensorflow-estimator {{ tf_version }}*
     - cudatoolkit {{ cuda_compiler_version }}*  # [cuda_compiler_version != 'None']
     - scikit-build
     - m2r

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,10 @@ requirements:
     - scipy
     - {{ pin_compatible('tensorflow', max_pin='x.x') }}  # [cuda_compiler_version == 'None']
     - {{ pin_compatible('tensorflow-gpu', max_pin='x.x') }}  # [cuda_compiler_version != 'None' and cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1']
-    - tensorflow-gpu {{ tf_version }}* # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
+    - {{ pin_compatible('tensorflow-base', max_pin='x.x') }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
+    - tensorboard >= {{ tf_version }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
+    - tensorflow-estimator >= {{ tf_version }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
+    - _tflow_select 2.1.0 gpu # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}*  # [cuda_compiler_version != 'None']
     - dargs
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - setuptools_scm
     - tensorflow {{ tf_version }}*  # [cuda_compiler_version == 'None']
     - tensorflow-gpu {{ tf_version }}*  # [cuda_compiler_version != 'None']
-    - tensorflow-estimator {{ tf_version }}*
+    - hdf5 1.10.6
     - cudatoolkit {{ cuda_compiler_version }}*  # [cuda_compiler_version != 'None']
     - scikit-build
     - m2r

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,8 @@ requirements:
   host:
     - python
     - pip
-    - numpy
+    - numpy # [cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1' ]
+    - numpy 1.20.* # [cuda_compiler_version == '11.0' or cuda_compiler_version == '11.1' ]
     - setuptools_scm
     - tensorflow {{ tf_version }}*  # [cuda_compiler_version == 'None']
     - tensorflow-gpu {{ tf_version }}*  # [cuda_compiler_version != 'None']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,8 +74,8 @@ requirements:
     - {{ pin_compatible('tensorflow', max_pin='x.x') }}  # [cuda_compiler_version == 'None']
     - {{ pin_compatible('tensorflow-gpu', max_pin='x.x') }}  # [cuda_compiler_version != 'None' and cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1']
     - {{ pin_compatible('tensorflow-base', max_pin='x.x') }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
-    - tensorboard >= {{ tf_version }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
-    - tensorflow-estimator >= {{ tf_version }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
+    - tensorboard >={{ tf_version }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
+    - tensorflow-estimator >={{ tf_version }} # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
     - _tflow_select 2.1.0 gpu # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}*  # [cuda_compiler_version != 'None']
     - dargs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,8 @@ requirements:
     - numpy
     - setuptools_scm
     - tensorflow {{ tf_version }}*  # [cuda_compiler_version == 'None']
-    - tensorflow-gpu {{ tf_version }}*  # [cuda_compiler_version != 'None']
+    - tensorflow-gpu {{ tf_version }}*  # [cuda_compiler_version != 'None' and cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1']
+    - tensorflow-base {{ tf_version }}* gpu* # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
     - hdf5 1.10.6
     - cudatoolkit {{ cuda_compiler_version }}*  # [cuda_compiler_version != 'None']
     - scikit-build
@@ -71,7 +72,8 @@ requirements:
     - numpy
     - scipy
     - {{ pin_compatible('tensorflow', max_pin='x.x') }}  # [cuda_compiler_version == 'None']
-    - {{ pin_compatible('tensorflow-gpu', max_pin='x.x') }}  # [cuda_compiler_version != 'None']
+    - {{ pin_compatible('tensorflow-gpu', max_pin='x.x') }}  # [cuda_compiler_version != 'None' and cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1']
+    - tensorflow-gpu {{ tf_version }}* # [cuda_compiler_version == '11.0' or cuda_compiler_version=='11.1']
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}*  # [cuda_compiler_version != 'None']
     - dargs
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,7 @@ requirements:
   host:
     - python
     - pip
-    - numpy # [cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1' ]
-    - numpy 1.20.* # [cuda_compiler_version == '11.0' or cuda_compiler_version == '11.1' ]
+    - numpy
     - setuptools_scm
     - tensorflow {{ tf_version }}*  # [cuda_compiler_version == 'None']
     - tensorflow-gpu {{ tf_version }}*  # [cuda_compiler_version != 'None']
@@ -68,8 +67,7 @@ requirements:
 
   run:
     - python
-    - numpy # [cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1' ]
-    - numpy >=1.20 # [cuda_compiler_version == '11.0' or cuda_compiler_version == '11.1' ]
+    - numpy
     - scipy
     - {{ pin_compatible('tensorflow', max_pin='x.x') }}  # [cuda_compiler_version == 'None']
     - {{ pin_compatible('tensorflow-gpu', max_pin='x.x') }}  # [cuda_compiler_version != 'None']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,8 @@ requirements:
 
   run:
     - python
-    - numpy
+    - numpy # [cuda_compiler_version != '11.0' and cuda_compiler_version != '11.1' ]
+    - numpy >=1.20 # [cuda_compiler_version == '11.0' or cuda_compiler_version == '11.1' ]
     - scipy
     - {{ pin_compatible('tensorflow', max_pin='x.x') }}  # [cuda_compiler_version == 'None']
     - {{ pin_compatible('tensorflow-gpu', max_pin='x.x') }}  # [cuda_compiler_version != 'None']


### PR DESCRIPTION
- v2.0.0.a1
- v2.0.0.b0
- MNT: Re-rendered with conda-build 3.21.4, conda-smithy 3.10.1, and conda-forge-pinning 2021.05.19.20.23.18
- add cuda11 support
- MNT: Re-rendered with conda-build 3.21.4, conda-smithy 3.10.1, and conda-forge-pinning 2021.06.01.05.21.06
